### PR TITLE
Fixed mode again

### DIFF
--- a/includes/MsgFormat.hpp
+++ b/includes/MsgFormat.hpp
@@ -42,6 +42,7 @@ class MsgFormat {
 		static std::string invalidKey(Client &client, const std::string &channelName);
 		static std::string keySet(Client &client, const std::string &channelName, const std::string &key);
 		static std::string changeOpStatus(Client &client, Client *target, const std::string &channelName, bool set);
+		static std::string channelLimit(Client &client, const std::string &channelName, const std::string &limit);
 		static std::string channelFull(Client &client, const std::string &channelName);
         static std::string modeactive(const std::string &channelName, std::string mode);
         static std::string userAlreadyInUse(const std::string &username);

--- a/srcs/MsgFormat.cpp
+++ b/srcs/MsgFormat.cpp
@@ -150,6 +150,11 @@ std::string MsgFormat::changeOpStatus(Client &client, Client *target, const std:
 	return (":" + client.getNickname() + "!" + client.getName() + "@" + client.getHostname() + " MODE " + channelName + " " + mode + " " + target->getNickname());
 }
 
+std::string MsgFormat::channelLimit(Client &client, const std::string &channelName, const std::string &limit)
+{
+	return (":" + client.getNickname() + "!" + client.getName() + "@" + client.getHostname() + " MODE " + channelName + " +l " + limit);
+}
+
 std::string MsgFormat::channelFull(Client &client, const std::string &channelName)
 {
 	return (":server 471 " + client.getNickname() + " " + channelName + " :Cannot join channel (+l)");

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -353,6 +353,7 @@ void ServerManager::handleMode(Client &client, std::vector<std::string> vec, siz
 	}
 	else if (channel->isNew())
 	{
+		std::cout << "New channel, returning..." << std::endl;
 		channel->setNew(false);
 		return;
 	}
@@ -367,6 +368,7 @@ void ServerManager::handleMode(Client &client, std::vector<std::string> vec, siz
 		return;
 	}
 
+	std::cout << "Not a new channel, continuing" << std::endl;
 	std::string mode = vec[i++];
 	if (mode.size() != 2 && mode[0] != '+' && mode[0] != '-')
 	{

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -91,8 +91,6 @@ void ServerManager::handleJoinCommand(Client& client, const std::string& channel
 	}	
 	else if (!channel->addClient(&client))
 		return;
-	else
-		channel->setNew(false);
 
 	if (channel->isInviteOnly() && !channel->isInvited(&client))
 	{
@@ -353,8 +351,11 @@ void ServerManager::handleMode(Client &client, std::vector<std::string> vec, siz
 		MsgFormat::MsgforHex(client.getSocket(), MsgFormat::channelNotFound(client, channelName));
 		return;
 	}
-	else if (!channel->isNew())
+	else if (channel->isNew())
+	{
+		channel->setNew(false);
 		return;
+	}
 	else if (!channel->searchOperator(client.getNickname()))
 	{
 		MsgFormat::MsgforHex(client.getSocket(), MsgFormat::notChannelOperator(client, channelName));
@@ -363,7 +364,6 @@ void ServerManager::handleMode(Client &client, std::vector<std::string> vec, siz
 	else if(channel->searchOperator(client.getNickname()) && channel->isNew())
 	{
 		MsgFormat::MsgforHex(client.getSocket(), MsgFormat::modeactive(channel->getName(), channel->getModes()));
-		channel->setNew(false);
 		return;
 	}
 

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -416,7 +416,14 @@ void ServerManager::handleMode(Client &client, std::vector<std::string> vec, siz
 				return;
 			}
 		}
-		channel->setUserLimit(set ? std::atoi(vec[i].c_str()) : 0);
+
+		int limit = std::atoi(vec[i].c_str());
+		channel->setUserLimit(set ? limit : 0);
+		if (set)
+		{
+			channel->sendMessageToClients(MsgFormat::channelLimit(client, channelName, vec[i]));
+			return;
+		}
 	}
 	else if (modeFlag == 'k')
 	{

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -282,14 +282,16 @@ void ServerManager::handleKick(Client &client, const std::string &channelName, c
 	}
 
 	Client *target = getClientByNick(targetNick);
-
-	if (!channel->searchNames(targetNick) || channel->searchOperator(targetNick))
+	if (!channel->searchNames(targetNick))
 	{
 		MsgFormat::MsgforHex(client.getSocket(), MsgFormat::userNotInChannel(client, channelName, targetNick));
 		return;
 	}
 	if (channel->isInvited(target))
 		channel->removeInvite(target);
+	if (channel->searchOperator(targetNick))
+		channel->removeOperator(target);
+
 	std::string reason;
 	for (size_t j = i; j < vec.size(); ++j)
 		reason += vec[j] + " ";


### PR DESCRIPTION
The previous PR completely broke the "/mode" command. This new one fixes it whilst also removing the "/mode +t" at the start of the channel (which I believe is not intended behavior), while also adding a default reason for kicking a client.