### PR TITLE
Mode channel fix

### DIFF
--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -10,12 +10,13 @@ class MsgFormat;
 
 class Client {
     private:
-        std::string             _name;
-        std::string             _nickname;
-        int                     _socketClient;
-        std::string             _hostname;
-        bool                    _authenticated;
-        std::string             _bufferMsg;
+        std::string _name;
+        std::string _nickname;
+        int         _socketClient;
+        std::string _hostname;
+        bool        _authenticated;
+        std::string _bufferMsg;
+		bool	    _newChannel;
 
     public:
         Client(int clientSocket);
@@ -24,9 +25,11 @@ class Client {
         void setSocket(int socketClient);
         void setName(std::string name);
         void setNickname(std::string nickname);
+		void setNewChannel(bool set);
         std::string getName() const;
         std::string getNickname() const;
         std::string getHostname();
+		bool hasEnteredNewChannel(void) const;
         bool operator==(Client const &client);
         void isAuthenticated();
         bool getAuthenticated() const;

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -3,6 +3,7 @@
 Client::Client(int clientSocket) {
    _socketClient =  clientSocket;
    _authenticated = false;
+   _newChannel = true;
 }
 
 Client:: ~Client(){
@@ -64,6 +65,16 @@ bool Client::getAuthenticated() const{
 	if(!_authenticated)
 		MsgFormat::MsgforHex(_socketClient, MsgFormat::UserNotAutenticated());
 	return _authenticated;
+}
+
+void Client::setNewChannel(bool set)
+{
+	_newChannel = set;
+}
+
+bool Client::hasEnteredNewChannel(void) const
+{
+	return (_newChannel);
 }
 
 bool Client::checkLoginData(){

--- a/srcs/MsgFormat.cpp
+++ b/srcs/MsgFormat.cpp
@@ -155,15 +155,8 @@ std::string MsgFormat::channelFull(Client &client, const std::string &channelNam
 	return (":server 471 " + client.getNickname() + " " + channelName + " :Cannot join channel (+l)");
 }
 
-std::string MsgFormat::modeactive(const std::string &channelName, std::string mode){
-	return(":server MODE " + channelName + " " + mode);
-
-}
-
-
 std::string MsgFormat::userAlreadyInUse(const std::string &username){
 	return(":server 400 " + username + " :Username is already in use");
-
 }
 
 

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -356,15 +356,14 @@ void ServerManager::handleMode(Client &client, std::vector<std::string> vec, siz
 		MsgFormat::MsgforHex(client.getSocket(), MsgFormat::channelNotFound(client, channelName));
 		return;
 	}
+	else if (channel->isNew())
+	{
+		channel->setNew(false);
+		return;
+	}
 	else if (!channel->searchOperator(client.getNickname()))
 	{
 		MsgFormat::MsgforHex(client.getSocket(), MsgFormat::notChannelOperator(client, channelName));
-		return;
-	}
-	else if(channel->searchOperator(client.getNickname()) && channel->isNew())
-	{
-		MsgFormat::MsgforHex(client.getSocket(), MsgFormat::modeactive(channel->getName(), channel->getModes()));
-		channel->setNew(false);
 		return;
 	}
 

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -349,16 +349,17 @@ void ServerManager::handleInvite(Client &client, const std::string &targetNick, 
 
 void ServerManager::handleMode(Client &client, std::vector<std::string> vec, size_t i)
 {
+	if (client.hasEnteredNewChannel())
+	{
+		client.setNewChannel(false);
+		return;
+	}
+
 	std::string channelName = vec[i++];
 	Channel	*channel = getChannelByName(channelName);
 	if (!channel)
 	{
 		MsgFormat::MsgforHex(client.getSocket(), MsgFormat::channelNotFound(client, channelName));
-		return;
-	}
-	else if (channel->isNew())
-	{
-		channel->setNew(false);
 		return;
 	}
 	else if (!channel->searchOperator(client.getNickname()))


### PR DESCRIPTION
This fixes for good the issue that when connecting to a channel, HexChat will automatically try to change the mode of such channel to the channel name (in other words, it sends the command "MODE #<channel name>").